### PR TITLE
Fix v1time computation on 32-bit platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "version": "1.4.1",
   "dependencies": {
-    "bignum": "^0.9.0",
     "microtime": ">=0.4.0"
   },
   "licenses": [


### PR DESCRIPTION
Work around https://github.com/justmoon/node-bignum/issues/52 by removing the `bignum` dependency and replacing the computation with 53 bit JavaScript integer arithmetic.
